### PR TITLE
api/paths: fix Lua interop, use home directory as fallback for config directory

### DIFF
--- a/src/api/paths.rs
+++ b/src/api/paths.rs
@@ -1,5 +1,3 @@
-use anyhow::anyhow;
-use directories::UserDirs;
 use mlua::{IntoLuaMulti, Lua, MultiValue, Result as LuaResult, Value};
 use std::{fs, path::PathBuf};
 
@@ -9,18 +7,8 @@ use crate::{
     util::{change_working_directory, get_executable_dir},
 };
 
-pub fn get_user_path(_: &Lua, _: ()) -> LuaResult<anyhow::Result<PathBuf>> {
-    let user_dirs = match UserDirs::new() {
-        Some(user_dirs) => user_dirs,
-        None => return Ok(Err(anyhow!("Failed to retrieve user's home directory"))),
-    };
-
-    match user_dirs.document_dir() {
-        Some(docs_dir) => Ok(Ok(docs_dir.canonicalize().unwrap())),
-        None => Ok(Err(anyhow!(
-            "Failed to retrieve user's documents directory"
-        ))),
-    }
+pub fn get_user_path(_: &Lua, _: ()) -> LuaResult<PathBuf> {
+    Ok(Game::user_data_dir())
 }
 
 // parent directory of Launch.lua script

--- a/src/args.rs
+++ b/src/args.rs
@@ -31,11 +31,19 @@ impl Game {
         GAME_CONFIG.get().expect("Game should be initialized")
     }
 
-    pub fn script_dir() -> PathBuf {
+    pub fn data_dir() -> PathBuf {
         let directory_name = match Self::current() {
             Game::Poe1 => "RustyPathOfBuilding1",
             Game::Poe2 => "RustyPathOfBuilding2",
         };
         BaseDirs::new().unwrap().data_dir().join(directory_name)
+    }
+
+    pub fn script_dir() -> PathBuf {
+        Game::data_dir()
+    }
+
+    pub fn user_data_dir() -> PathBuf {
+        Game::data_dir().join("userdata")
     }
 }


### PR DESCRIPTION
Two things here: 

- `documents_dir()` will return `None` if `~/Documents` does not exist, _or_ if `XDG_DOCUMENTS_DIR` equals `HOME`, so there should probably be a fallback instead of a difficult to debug failure. My personal preference would be to even put this stuff into ~/.local/share, but that's a question of taste, really.
- When `documents_dir()` does fail, the function returns `LuaResult::Ok(anyhow::Result<_>::Err(...))`, which is marshaled to Lua as an opaque value but does _not_ raise a Lua error, so the whole thing explodes in an unnecessarily confusing way.