### PR TITLE
Fix bug accidentally requiring extra features for surface format

### DIFF
--- a/src/gfx.rs
+++ b/src/gfx.rs
@@ -95,7 +95,7 @@ impl GraphicsContext {
         let surface_format = surface_caps
             .formats
             .iter()
-            .find(|f| !f.is_srgb())
+            .find(|f| !f.is_srgb() && f.required_features().is_empty())
             .copied()
             .unwrap_or(surface_caps.formats[0]);
 


### PR DESCRIPTION
On my system, surface_formats() has `Rgba16Unorm` as the first format in the surface_caps.formats vector that isn't SRGB. However if this format is used it requires a couple of extra WGPU features that weren't requested for the device.

This specific format isn't actually required and so the features aren't required, so instead we can just skip over any formats that require features when skipping srgb ones. This results in an appropriate format being selected and gets rid of a potential wgpu crash.