### PR TITLE
fix removing build directory

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -9,7 +9,8 @@ use crate::{
         input::{get_cursor_pos, is_key_down},
         lua::{load_module, protected_call, protected_load_module},
         paths::{
-            get_runtime_path, get_script_path, get_user_path, get_work_dir, make_dir, set_work_dir,
+            get_runtime_path, get_script_path, get_user_path, get_work_dir, make_dir, remove_dir,
+            set_work_dir,
         },
         rendering::PoBString,
         search_handle::new_search_handle,
@@ -51,6 +52,7 @@ pub fn register_globals(lua: &Lua) -> LuaResult<()> {
     globals.set("GetWorkDir", lua.create_function(get_work_dir)?)?;
     globals.set("SetWorkDir", lua.create_function(set_work_dir)?)?;
     globals.set("MakeDir", lua.create_function(make_dir)?)?;
+    globals.set("RemoveDir", lua.create_function(remove_dir)?)?;
 
     // console
     globals.set("ConPrintf", lua.create_function(console_printf)?)?;

--- a/src/api/paths.rs
+++ b/src/api/paths.rs
@@ -47,3 +47,15 @@ pub fn make_dir(l: &Lua, path: String) -> LuaResult<MultiValue> {
         Err(err) => Ok((Value::Nil, err.to_string()).into_lua_multi(l)?),
     }
 }
+
+pub fn remove_dir(l: &Lua, (path, recursive): (String, Option<bool>)) -> LuaResult<MultiValue> {
+    let result = if recursive.unwrap_or(false) {
+        fs::remove_dir_all(&path)
+    } else {
+        fs::remove_dir(&path)
+    };
+    match result {
+        Ok(_) => Ok(Value::Boolean(true).into_lua_multi(l)?),
+        Err(err) => Ok((Value::Nil, err.to_string()).into_lua_multi(l)?),
+    }
+}


### PR DESCRIPTION
Hi, 

I found another "me" specific bug. 
Removing folder in build list menu was showing an error

```lua
Error:

In 'OnFrame': runtime error: .../share/RustyPathOfBuilding1/Classes/BuildListControl.lua:152: attempt to call global 'RemoveDir' (a nil value)
stack traceback:
	[C]: in function 'RemoveDir'
	.../share/RustyPathOfBuilding1/Classes/BuildListControl.lua:152: in function 'DeleteBuild'
	.../.local/share/RustyPathOfBuilding1/Modules/BuildList.lua:62: in function 'OnKeyUp'
	...local/share/RustyPathOfBuilding1/Classes/ControlHost.lua:57: in function 'ProcessControlsInput'
	.../.local/share/RustyPathOfBuilding1/Modules/BuildList.lua:176: in function 'CallMode'
	...satan/.local/share/RustyPathOfBuilding1/Modules/Main.lua:371: in function <...satan/.local/share/RustyPathOfBuilding1/Modules/Main.lua:341>
	[C]: in function 'PCall'
	/home/aisatan/.local/share/RustyPathOfBuilding1/Launch.lua:111: in function </home/aisatan/.local/share/RustyPathOfBuilding1/Launch.lua:108>
v2.60.0-d31d44da beta
Press Enter/Escape to dismiss, or F5 to restart the application.
Press CTRL + C to copy error text.
``` 

So I fixed it, it should behave as expected:
- remove empty directory
- asks first if directory contains builds

<img width="408" height="259" alt="image" src="https://github.com/user-attachments/assets/fddee0f6-c371-47b9-b846-e5bb93b61999" />
