### PR TITLE
Refactor installer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,6 +294,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,6 +572,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "codespan-reporting"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,6 +625,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,7 +647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -619,7 +660,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "libc",
 ]
 
@@ -789,10 +830,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "env_logger"
@@ -925,6 +981,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,10 +1058,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -1014,7 +1113,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1036,8 +1138,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1047,9 +1151,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1101,6 +1207,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1177,6 +1302,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,6 +1337,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
 name = "icu_locale_core"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,6 +1423,83 @@ dependencies = [
  "serde",
  "tinystr",
  "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -1255,6 +1556,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -1464,6 +1781,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "lz4_flex"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1495,6 +1818,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1502,6 +1831,17 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2003,6 +2343,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2124,6 +2470,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2181,6 +2533,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -2279,6 +2640,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2486,6 +2903,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "resize"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2565,13 +3022,24 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
- "log",
+ "aws-lc-rs",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -2580,8 +3048,36 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -2589,6 +3085,7 @@ version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2629,10 +3126,10 @@ dependencies = [
  "puffin_http",
  "raw-window-handle",
  "regex",
+ "reqwest",
  "smithay-clipboard",
  "swash",
  "tar",
- "ureq",
  "wgpu",
  "winit",
  "zstd",
@@ -2645,6 +3142,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2670,6 +3176,29 @@ dependencies = [
  "memmap2",
  "smithay-client-toolkit 0.19.2",
  "tiny-skia",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2818,6 +3347,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2876,6 +3415,47 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2975,6 +3555,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.0.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3005,6 +3637,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3020,6 +3697,15 @@ name = "tracing-core"
 version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ttf-parser"
@@ -3052,39 +3738,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "ureq"
-version = "3.3.0"
+name = "url"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
- "base64",
- "flate2",
- "log",
+ "form_urlencoded",
+ "idna",
  "percent-encoding",
- "rustls",
- "rustls-pki-types",
- "ureq-proto",
- "utf8-zero",
- "webpki-roots",
+ "serde",
 ]
 
 [[package]]
-name = "ureq-proto"
-version = "0.6.0"
+name = "utf8_iter"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
-dependencies = [
- "base64",
- "http",
- "httparse",
- "log",
-]
-
-[[package]]
-name = "utf8-zero"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -3117,6 +3786,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -3349,10 +4027,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
+name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3494,8 +4172,8 @@ checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-result",
- "windows-strings",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
 
@@ -3528,6 +4206,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3537,13 +4226,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -3792,7 +4499,7 @@ dependencies = [
  "calloop 0.13.0",
  "cfg_aliases",
  "concurrent-queue",
- "core-foundation",
+ "core-foundation 0.9.4",
  "core-graphics",
  "cursor-icon",
  "dpi",
@@ -3941,6 +4648,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeno"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3971,6 +4701,21 @@ name = "zerofrom"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "zeroize"
@@ -3979,13 +4724,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
 name = "zerovec"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "serde",
+ "yoke",
  "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,9 @@ profiling = "1.0"
 puffin_http = { version = "0.16", optional = true }
 raw-window-handle = "0.6.2"
 regex = "1.11.2"
+reqwest = { version = "0.13.2", features = ["blocking"] }
 swash = "0.2.5"
 tar = "0.4.44"
-ureq = "3.1.2"
 wgpu = { version = "27.0.1", default-features = false, features = ["std", "parking_lot", "vulkan", "wgsl"] }
 winit = "0.30"
 zstd = "0.13.3"

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -4,55 +4,47 @@ use crate::{
     color::Srgba,
     dpi::{LogicalPoint, LogicalRect},
     fonts::{Alignment, FontStyle, LayoutJob},
+    installer::download::{
+        DownloadEvent, ExtractionRule, build_client, download_and_extract_tarball,
+        download_file_to_disk, fetch_file_contents,
+    },
     mode::{AppEvent, ModeFrameOutput, ModeTransition},
     renderer::primitives::{ClippedPrimitive, DrawPrimitive, TextPrimitive},
     util::replace_in_matching_lines,
 };
-use flate2::read::GzDecoder;
 use parley::{FontFamily, GenericFamily};
 use regex::Regex;
 use std::{
-    fs::{self},
-    io::copy,
-    path::{Path, PathBuf},
-    sync::mpsc::{self, Receiver, TryRecvError},
+    fs,
+    path::Path,
+    sync::{
+        LazyLock,
+        mpsc::{self, Receiver, TryRecvError},
+    },
     thread,
 };
-use std::{
-    sync::LazyLock,
-    time::{Duration, SystemTime, UNIX_EPOCH},
-};
-use ureq::{Agent, http::Response};
 
-const REPO_NAME: &str = "meehl/rusty-pob-manifest";
+mod download;
+
+const COMPAT_REPO: &str = "meehl/rusty-pob-manifest";
+
 static VERSION_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^(\d+)\.(\d+)\.(\d+)$").unwrap());
 
-enum DownloadProgress {
-    Percentage(f32), // percentage of total size (between 0 and 1)
-    TotalBytes(u64), // amount of bytes downloaded
-}
+static MANIFEST_VERSION_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"<Version").unwrap());
 
 enum Progress {
     Status(String),
-    Download(DownloadProgress),
     Complete,
     Error(anyhow::Error),
 }
 
-enum CurrentProgress {
-    Starting,
-    Status(String),
-    Download(DownloadProgress),
-}
-
-/// Execution mode in which PoB's assets are downloaded if they don't exist yet.
+/// Execution mode in which initial installation of PoB is performed.
 ///
-/// Immediately transitions into PoB mode if assets already exist. Otherwise,
-/// it downloads them to the user directory and displays the download progress.
+/// Immediately transitions into PoB mode if already installed.
 pub struct InstallMode {
     progress_rx: Option<Receiver<Progress>>,
-    current_progress: CurrentProgress,
+    status: String,
 }
 
 impl InstallMode {
@@ -62,15 +54,15 @@ impl InstallMode {
 
         thread::spawn(move || {
             if let Err(err) = install(script_dir.as_path(), game, &progress_tx) {
-                progress_tx.send(Progress::Error(err)).unwrap();
+                let _ = progress_tx.send(Progress::Error(err));
                 return;
             }
-            progress_tx.send(Progress::Complete).unwrap();
+            let _ = progress_tx.send(Progress::Complete);
         });
 
         Self {
             progress_rx: Some(progress_rx),
-            current_progress: CurrentProgress::Starting,
+            status: String::from("Starting installation..."),
         }
     }
 
@@ -88,20 +80,13 @@ impl InstallMode {
         if let Some(progress_rx) = &self.progress_rx {
             loop {
                 match progress_rx.try_recv() {
-                    Ok(Progress::Download(progress)) => {
-                        self.current_progress = CurrentProgress::Download(progress);
-                    }
-                    Ok(Progress::Status(msg)) => {
-                        self.current_progress = CurrentProgress::Status(msg);
-                    }
-                    Ok(Progress::Complete) => {
-                        return Ok(Some(ModeTransition::PoB));
-                    }
+                    Ok(Progress::Status(msg)) => self.status = msg,
+                    Ok(Progress::Complete) => return Ok(Some(ModeTransition::PoB)),
                     Ok(Progress::Error(err)) => {
-                        return Err(anyhow::anyhow!("Download failed: {}", err));
+                        return Err(anyhow::anyhow!("Installation failed: {err}"));
                     }
                     Err(TryRecvError::Disconnected) => {
-                        return Err(anyhow::anyhow!("Download thread disconnected!"));
+                        return Err(anyhow::anyhow!("Install thread disconnected unexpectedly"));
                     }
                     Err(TryRecvError::Empty) => {
                         break;
@@ -134,24 +119,10 @@ impl InstallMode {
             FontStyle::Normal,
         );
 
-        let progress_text = match &self.current_progress {
-            CurrentProgress::Starting => String::from("Starting download..."),
-            CurrentProgress::Status(msg) => msg.clone(),
-            CurrentProgress::Download(progress) => match progress {
-                DownloadProgress::Percentage(progress) => {
-                    let percent = (progress * 100.0) as u32;
-                    format!("Downloading assets... ({})", percent)
-                }
-                DownloadProgress::TotalBytes(total_bytes) => {
-                    format!("Downloading assets... ({})", format_bytes(*total_bytes))
-                }
-            },
-        };
-        job.append(&progress_text, Srgba::WHITE);
+        job.append(&self.status, Srgba::WHITE);
 
         let layout = app_state.fonts.layout(job, app_state.window.scale_factor());
 
-        // center text vertically and horizontally
         let screen_size = app_state.window.logical_size().cast::<f32>();
         let pos = LogicalPoint::new(screen_size.width / 2.0, screen_size.height / 2.0);
 
@@ -162,52 +133,62 @@ impl InstallMode {
             primitive: DrawPrimitive::Text(primitive),
         };
 
-        let primitives = vec![clipped_primitive];
-        Box::new(primitives.into_iter())
+        Box::new(vec![clipped_primitive].into_iter())
     }
 }
 
+// Helper function for writing status to both the message channel and the log
+fn report(tx: &mpsc::Sender<Progress>, msg: impl Into<String>) {
+    let msg = msg.into();
+    log::info!("{msg}");
+    let _ = tx.send(Progress::Status(msg));
+}
+
+/// Performs full installation of PoB assets into `target_dir`.
+///
+/// Skips installation if `rpob.version` already exists.
+///
+/// Steps:
+/// 1. Fetch the compatibility table to determine which PoB version is
+///    supported by the current Rusty PoB version.
+/// 2. Download and extract the PoB release tarball into `target_dir`.
+/// 3. Replace `UpdateCheck.lua` with a patched version and update its
+///    checksum in `manifest.xml`. This is needed to support PoB native updater.
+/// 4. Set the branch and platform fields in `manifest.xml`.
+/// 5. Write `rpob.version` to mark the installation as complete.
 fn install<P: AsRef<Path>>(
     target_dir: P,
     game: Game,
     progress_tx: &mpsc::Sender<Progress>,
 ) -> anyhow::Result<()> {
-    // Skip installation if version file exists
-    let current_version = env!("CARGO_PKG_VERSION");
-    let version_file_path = target_dir.as_ref().join("rpob.version");
-    if version_file_path.exists() {
-        let old_version = fs::read_to_string(&version_file_path).unwrap();
+    let target_dir = target_dir.as_ref();
+    let client = build_client()?;
 
+    let version_file_path = target_dir.join("rpob.version");
+    let current_version = env!("CARGO_PKG_VERSION");
+    if version_file_path.exists() {
+        let old_version = fs::read_to_string(&version_file_path)?;
         if old_version != current_version {
-            log::info!("New version detected: {old_version} -> {current_version}");
+            log::info!("Version changed: {old_version} -> {current_version}");
             fs::write(&version_file_path, current_version).unwrap();
         }
-
         return Ok(());
     }
 
-    progress_tx.send(Progress::Status("Fetching compatibility info...".into()))?;
-    log::info!("Fetching compatibility info...");
-    let compatibility_info = fetch_compatibility_info(game)?;
-
-    progress_tx.send(Progress::Status("Resolving PoB version...".into()))?;
-    log::info!("Resolving supported PoB version...");
-    let needed_pob_version = highest_supported_pob_version(&compatibility_info, current_version)
+    report(progress_tx, "Fetching compatibility info...");
+    let compat_info = fetch_compatibility_info(&client, game)?;
+    let pob_version = highest_supported_pob_version(&compat_info, current_version)
         .ok_or_else(|| anyhow::anyhow!("Unable to determine supported PoB version"))?;
-    log::info!("Using PoB version: {needed_pob_version}");
+    log::info!("Using PoB version: {pob_version}");
 
-    progress_tx.send(Progress::Status("Downloading assets...".into()))?;
-    download_path_of_building(&target_dir, game, needed_pob_version, progress_tx)?;
+    report(progress_tx, "Downloading assets...");
+    download_pob(&client, target_dir, game, pob_version, progress_tx)?;
 
-    progress_tx.send(Progress::Status("Patching UpdateCheck...".into()))?;
-    log::info!("Patching UpdateCheck...");
-    replace_updatecheck(&target_dir)?;
+    report(progress_tx, "Finalizing installation...");
+    replace_updatecheck(&client, target_dir)?;
+    set_branch_and_platform(target_dir)?;
 
-    progress_tx.send(Progress::Status("Finalizing installation...".into()))?;
-    log::info!("Finalizing installation...");
-    set_branch_and_platform(&target_dir)?;
-
-    fs::write(&version_file_path, env!("CARGO_PKG_VERSION")).unwrap();
+    fs::write(&version_file_path, current_version)?;
     log::info!("Installation complete.");
 
     Ok(())
@@ -219,30 +200,27 @@ struct VersionReq {
     min_rpob_ver: String,
 }
 
-/// Fetches and evaluates compatibility table
-fn fetch_compatibility_info(game: Game) -> anyhow::Result<Vec<VersionReq>> {
-    let compatibility_info_file_name = match game {
+/// Fetches compatibility info
+fn fetch_compatibility_info(
+    client: &reqwest::blocking::Client,
+    game: Game,
+) -> anyhow::Result<Vec<VersionReq>> {
+    let file_name = match game {
         Game::Poe1 => "Compatibility_pob1.lua",
         Game::Poe2 => "Compatibility_pob2.lua",
     };
 
-    let compatibility_info_file_url = &format!(
-        "https://raw.githubusercontent.com/{REPO_NAME}/main/{}",
-        compatibility_info_file_name
-    );
-
-    let compatibility_info_file = download_file_contents(compatibility_info_file_url)?;
+    let compatibility_info_file = fetch_file_contents(client, COMPAT_REPO, file_name)?;
 
     // Load and evaluate compatibility file contents as Lua code
     let lua = mlua::Lua::new();
     let compatibility_table = lua.load(compatibility_info_file).eval::<mlua::Table>()?;
 
-    // Compatibility table maps PoB version to minimum required Rusty PoB version
+    // Compatibility table maps PoB version to minimum required Rusty PoB version.
+    // Beta versions have a non-semver suffix and are filtered out by the regex.
     Ok(compatibility_table
         .pairs::<String, String>()
         .filter_map(|p| p.ok())
-        // filter out beta versions. beta version adds a suffix to the version string which is not
-        // matched by the version regex resulting in them being filtered out
         .filter(|(pob_version, _)| VERSION_RE.is_match(pob_version))
         .map(|(pob_version, min_req_rpob_ver)| VersionReq {
             pob_ver: pob_version,
@@ -251,202 +229,145 @@ fn fetch_compatibility_info(game: Game) -> anyhow::Result<Vec<VersionReq>> {
         .collect())
 }
 
-/// Determines highest PoB version supported by given Rusty PoB version
+/// Determines the highest PoB version supported by the given Rusty PoB version.
 fn highest_supported_pob_version<'a>(
-    compatibility_info: &'a Vec<VersionReq>,
+    compatibility_info: &'a [VersionReq],
     rpob_version: &str,
 ) -> Option<&'a str> {
-    let mut highest_pob_version = None;
+    let mut highest: Option<&str> = None;
     for VersionReq {
         pob_ver,
         min_rpob_ver,
     } in compatibility_info
     {
         if is_higher_version(min_rpob_ver, rpob_version).unwrap_or(false) {
-            // found PoB version that meets our minimum requirements
-            match highest_pob_version {
-                // make sure it is the highest PoB version possible
-                Some(h_pob_version) => {
-                    if is_higher_version(h_pob_version, pob_ver).unwrap_or(false) {
-                        highest_pob_version = Some(pob_ver.as_str());
-                    }
-                }
-                None => highest_pob_version = Some(pob_ver.as_str()),
+            match highest {
+                Some(h) if !is_higher_version(h, pob_ver).unwrap_or(false) => {}
+                _ => highest = Some(pob_ver.as_str()),
             }
         }
     }
-
-    highest_pob_version
+    highest
 }
 
-/// Downloads specified version of Path of Building
-fn download_path_of_building<P: AsRef<Path>>(
+fn download_pob<P: AsRef<Path>>(
+    client: &reqwest::blocking::Client,
     target_dir: P,
     game: Game,
     pob_version: &str,
     progress_tx: &mpsc::Sender<Progress>,
 ) -> anyhow::Result<()> {
-    log::info!("Downloading Path of Building assets...");
+    let target_dir = target_dir.as_ref();
 
-    let repo = match game {
+    let pob_repo = match game {
         Game::Poe1 => "PathOfBuildingCommunity/PathOfBuilding",
         Game::Poe2 => "PathOfBuildingCommunity/PathOfBuilding-PoE2",
     };
-    let url = format!(
-        "https://github.com/{}/archive/refs/tags/v{}.tar.gz",
-        repo, pob_version
-    );
 
-    let mut response = http_get_with_backoff(&url)?;
-    let total_size = response
-        .headers()
-        .get("Content-Length")
-        .and_then(|s| s.to_str().ok()?.parse::<u64>().ok());
+    let rules = vec![
+        ExtractionRule::File {
+            tarball_path: "manifest.xml".into(),
+            dest_path: target_dir.join("manifest.xml"),
+        },
+        ExtractionRule::File {
+            tarball_path: "help.txt".into(),
+            dest_path: target_dir.join("help.txt"),
+        },
+        ExtractionRule::File {
+            tarball_path: "changelog.txt".into(),
+            dest_path: target_dir.join("changelog.txt"),
+        },
+        ExtractionRule::File {
+            tarball_path: "LICENSE.md".into(),
+            dest_path: target_dir.join("LICENSE.md"),
+        },
+        ExtractionRule::RewritePrefix {
+            prefix: "src/".into(),
+            dest_dir: target_dir.to_path_buf(),
+        },
+        ExtractionRule::RewritePrefix {
+            prefix: "runtime/lua/".into(),
+            dest_dir: target_dir.join("lua"),
+        },
+    ];
 
-    let body_reader = response.body_mut().as_reader();
-    let mut archive = tar::Archive::new(GzDecoder::new(body_reader));
-    let mut downloaded = 0u64;
-
-    for file in archive.entries()? {
-        let mut file = file?;
-        let file_path = file.path()?;
-        let components: Vec<_> = file_path.components().collect();
-
-        let target_path = match components.len() {
-            0..=1 => None,
-            // put these into target_dir/
-            2 => {
-                let filename = components[1].as_os_str();
-                if filename == "manifest.xml"
-                    || filename == "help.txt"
-                    || filename == "changelog.txt"
-                    || filename == "LICENSE.md"
-                {
-                    Some(target_dir.as_ref().join(filename))
-                } else {
-                    None
+    download_and_extract_tarball(
+        &client,
+        pob_repo,
+        &format!("v{pob_version}"),
+        &rules,
+        5,
+        &mut |event| {
+            let msg = match event {
+                DownloadEvent::Progress {
+                    downloaded,
+                    total: Some(total),
+                } => {
+                    let pct = (downloaded as f32 / total as f32 * 100.0) as u32;
+                    format!("Downloading assets... ({pct}%)")
                 }
-            }
-            // put lua runtime files into target_dir/lua/
-            3.. => {
-                if components[1].as_os_str() == "src"
-                    || (components[1].as_os_str() == "runtime"
-                        && components[2].as_os_str() == "lua")
-                {
-                    Some(
-                        target_dir
-                            .as_ref()
-                            .join(components[2..].iter().collect::<PathBuf>()),
-                    )
-                } else {
-                    None
+                DownloadEvent::Progress {
+                    downloaded,
+                    total: None,
+                } => {
+                    format!("Downloading assets... ({})", format_bytes(downloaded))
                 }
-            }
-        };
-
-        // create needed directories and extract
-        if let Some(target_path) = target_path {
-            if let Some(parent) = target_path.parent() {
-                fs::create_dir_all(parent)?;
-            }
-            file.unpack(&target_path)?;
-        }
-
-        downloaded += file.size();
-
-        if let Some(total) = total_size {
-            let progress = downloaded as f32 / total as f32;
-            progress_tx.send(Progress::Download(DownloadProgress::Percentage(progress)))?;
-        } else {
-            progress_tx.send(Progress::Download(DownloadProgress::TotalBytes(downloaded)))?;
-        }
-    }
-
+                DownloadEvent::Retrying { attempt } => {
+                    format!("Retrying... (Attempt {})", attempt)
+                }
+            };
+            let _ = progress_tx.send(Progress::Status(msg));
+        },
+    )?;
     Ok(())
 }
 
-/// Replaces UpdateCheck with rusty-path-of-building's modified version
-fn replace_updatecheck<P: AsRef<Path>>(target_dir: P) -> anyhow::Result<()> {
-    download_file(
-        &format!(
-            "https://raw.githubusercontent.com/{REPO_NAME}/main/{}",
-            "UpdateCheck.lua"
-        ),
-        target_dir.as_ref().join("UpdateCheck.lua"),
-    )?;
+/// Replaces UpdateCheck.lua with rusty-path-of-building's modified version and
+/// updates its checksum in manifest.xml.
+fn replace_updatecheck<P: AsRef<Path>>(
+    client: &reqwest::blocking::Client,
+    target_dir: P,
+) -> anyhow::Result<()> {
+    let target_dir = target_dir.as_ref();
+    let file_name = "UpdateCheck.lua";
 
-    // Replace original checksum with checksum of modified update script
-    let new_checksum = download_file_contents(&format!(
-        "https://raw.githubusercontent.com/{REPO_NAME}/main/{}",
-        "UpdateCheck.lua.sha1"
-    ))?;
+    download_file_to_disk(client, COMPAT_REPO, file_name, target_dir.join(file_name))?;
 
-    // file contains checksum followed by filename (separated by whitespace)
-    // we only need the checksum
-    let new_checksum = new_checksum
+    // .sha1 file format: "<checksum>  UpdateCheck.lua" - we only need the checksum.
+    let sha1_contents = fetch_file_contents(client, COMPAT_REPO, "UpdateCheck.lua.sha1")?;
+    let new_checksum = sha1_contents
         .split_whitespace()
         .next()
-        .ok_or_else(|| anyhow::anyhow!("Invalid checksum file"))?;
+        .ok_or_else(|| anyhow::anyhow!("Invalid checksum file format"))?;
 
-    let filename = target_dir.as_ref().join("manifest.xml");
-    let manifest = fs::read_to_string(&filename)?;
-
+    let manifest_path = target_dir.join("manifest.xml");
+    let manifest = fs::read_to_string(&manifest_path)?;
     let new_manifest = replace_in_matching_lines(
         &manifest,
         r#"name="UpdateCheck.lua""#,
         r#"sha1="([0-9A-Za-z]+)""#,
-        &format!(r#"sha1="{}""#, new_checksum),
+        &format!(r#"sha1="{new_checksum}""#),
     );
-
-    fs::write(&filename, &new_manifest)?;
+    fs::write(&manifest_path, &new_manifest)?;
 
     Ok(())
 }
 
 /// Sets branch and platform in manifest.xml
 fn set_branch_and_platform<P: AsRef<Path>>(target_dir: P) -> anyhow::Result<()> {
-    let filename = target_dir.as_ref().join("manifest.xml");
-    let manifest = fs::read_to_string(&filename)?;
+    let path = target_dir.as_ref().join("manifest.xml");
+    let manifest = fs::read_to_string(&path)?;
 
-    #[cfg(not(target_os = "windows"))]
-    let platform = std::env::consts::OS;
     #[cfg(target_os = "windows")]
     let platform = "win32";
+    #[cfg(not(target_os = "windows"))]
+    let platform = std::env::consts::OS;
 
-    let new_version = format!(r#"<Version branch="master" platform="{}""#, platform);
-
-    let version_regex = Regex::new(r"<Version").unwrap();
-    let new_manifest = version_regex.replace(&manifest, new_version);
-
-    fs::write(&filename, new_manifest.as_ref())?;
+    let replacement = format!(r#"<Version branch="master" platform="{platform}""#);
+    let new_manifest = MANIFEST_VERSION_RE.replace(&manifest, replacement);
+    fs::write(&path, new_manifest.as_ref())?;
 
     Ok(())
-}
-
-/// Downloads file and saves it to given path
-fn download_file<P: AsRef<Path>>(url: &str, file_path: P) -> anyhow::Result<()> {
-    let mut response = http_get_with_backoff(url)?;
-
-    if response.status().is_success() {
-        let body = response.body_mut();
-        let mut file = fs::File::create(file_path)?;
-        copy(&mut body.as_reader(), &mut file)?;
-        Ok(())
-    } else {
-        anyhow::bail!("Unable to download: {}", url);
-    }
-}
-
-/// Downloads file and returns contents as string
-fn download_file_contents(url: &str) -> anyhow::Result<String> {
-    let mut response = http_get_with_backoff(url)?;
-
-    if response.status().is_success() {
-        let body = response.body_mut();
-        Ok(body.read_to_string()?)
-    } else {
-        anyhow::bail!("Unable to download: {}", url);
-    }
 }
 
 fn format_bytes(size_in_bytes: u64) -> String {
@@ -461,120 +382,11 @@ fn format_bytes(size_in_bytes: u64) -> String {
     } else if size_in_bytes >= KB {
         format!("{:.2} KB", size_in_bytes as f64 / KB as f64)
     } else {
-        format!("{} bytes", size_in_bytes)
+        format!("{size_in_bytes} bytes")
     }
 }
 
-/// Calculates wait time based on rate limit headers or falls back to default backoff.
-fn calculate_wait_time(resp: &Response<ureq::Body>, default_backoff: u64) -> u64 {
-    let headers = resp.headers();
-
-    // Wait for time specified in retry-after response header if present
-    if let Some(retry_after) = headers
-        .get("retry-after")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.parse::<u64>().ok())
-    {
-        return retry_after;
-    }
-
-    // The number of requests remaining in the current rate limit window
-    let remaining = headers
-        .get("x-ratelimit-remaining")
-        .and_then(|v| v.to_str().ok());
-
-    if remaining == Some("0") {
-        // Calculate time until rate limit reset
-        if let Some(reset_epoch) = headers
-            .get("x-ratelimit-reset")
-            .and_then(|v| v.to_str().ok())
-            .and_then(|s| s.parse::<u64>().ok())
-        {
-            let now_epoch = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs();
-
-            if reset_epoch > now_epoch {
-                return reset_epoch - now_epoch;
-            }
-        }
-    }
-
-    default_backoff
-}
-
-/// Performs a GET request with exponential backoff aware of GitHub rate limit headers.
-fn http_get_with_backoff(url: &str) -> anyhow::Result<Response<ureq::Body>> {
-    const MAX_ATTEMPTS: usize = 6;
-    const MAX_BACKOFF_SECS: u64 = 60;
-    let mut attempt = 0;
-    let mut backoff_secs: u64 = 2;
-
-    let config = Agent::config_builder()
-        .timeout_global(Some(Duration::from_secs(10)))
-        .build();
-
-    let agent: Agent = config.into();
-
-    loop {
-        attempt += 1;
-        let resp_result = agent
-            .get(url)
-            .header("User-Agent", "rusty-path-of-building")
-            .call();
-
-        let resp = match resp_result {
-            Ok(r) => r,
-            Err(err) => {
-                log::warn!(
-                    "Transport error: {} (attempt {}/{})",
-                    err,
-                    attempt,
-                    MAX_ATTEMPTS
-                );
-                if attempt >= MAX_ATTEMPTS {
-                    return Err(anyhow::Error::new(err));
-                }
-                thread::sleep(Duration::from_secs(backoff_secs));
-                backoff_secs = (backoff_secs * 2).min(MAX_BACKOFF_SECS);
-                continue;
-            }
-        };
-
-        let status = resp.status();
-        if status == 403 || status == 429 {
-            let wait = calculate_wait_time(&resp, backoff_secs);
-
-            log::warn!(
-                "Rate limited (status {}). Waiting {}s before retry (attempt {}/{})",
-                status,
-                wait,
-                attempt,
-                MAX_ATTEMPTS
-            );
-            if attempt >= MAX_ATTEMPTS {
-                return Err(anyhow::anyhow!(
-                    "HTTP {} after {} attempts for {}",
-                    status,
-                    attempt,
-                    url
-                ));
-            }
-            thread::sleep(Duration::from_secs(wait));
-            backoff_secs = (backoff_secs * 2).min(MAX_BACKOFF_SECS);
-            continue;
-        }
-
-        if status.is_client_error() || status.is_server_error() {
-            return Err(anyhow::anyhow!("http status: {} for {}", status, url));
-        }
-
-        return Ok(resp);
-    }
-}
-
-/// Compares two SemVer versions and returns true if v2 is higher or equal than v1
+/// Returns true if `v2` is greater than or equal to `v1`.
 fn is_higher_version(v1: &str, v2: &str) -> anyhow::Result<bool> {
     let parse_version = |v: &str| -> anyhow::Result<(u32, u32, u32)> {
         let caps = VERSION_RE
@@ -602,25 +414,25 @@ mod tests {
 
     #[test]
     fn test_major_version() {
-        assert_eq!(is_higher_version("1.0.0", "2.0.0").unwrap(), true);
-        assert_eq!(is_higher_version("2.0.0", "1.0.0").unwrap(), false);
+        assert!(is_higher_version("1.0.0", "2.0.0").unwrap());
+        assert!(!is_higher_version("2.0.0", "1.0.0").unwrap());
     }
 
     #[test]
     fn test_minor_version() {
-        assert_eq!(is_higher_version("1.5.0", "1.6.0").unwrap(), true);
-        assert_eq!(is_higher_version("1.10.0", "1.9.0").unwrap(), false);
+        assert!(is_higher_version("1.5.0", "1.6.0").unwrap());
+        assert!(!is_higher_version("1.10.0", "1.9.0").unwrap());
     }
 
     #[test]
     fn test_patch_version() {
-        assert_eq!(is_higher_version("1.0.3", "1.0.4").unwrap(), true);
-        assert_eq!(is_higher_version("1.0.10", "1.0.9").unwrap(), false);
+        assert!(is_higher_version("1.0.3", "1.0.4").unwrap());
+        assert!(!is_higher_version("1.0.10", "1.0.9").unwrap());
     }
 
     #[test]
     fn test_same_version() {
-        assert_eq!(is_higher_version("1.5.3", "1.5.3").unwrap(), true);
+        assert!(is_higher_version("1.5.3", "1.5.3").unwrap());
     }
 
     #[test]
@@ -635,33 +447,33 @@ mod tests {
     fn test_highest_supported_pob_ver() {
         let compat_info = vec![
             VersionReq {
-                pob_ver: String::from("2.56.0"),
-                min_rpob_ver: String::from("0.1.0"),
+                pob_ver: "2.56.0".into(),
+                min_rpob_ver: "0.1.0".into(),
             },
             // compat info might not be sorted by pob_version
             VersionReq {
-                pob_ver: String::from("2.58.0"),
-                min_rpob_ver: String::from("0.2.6"),
+                pob_ver: "2.58.0".into(),
+                min_rpob_ver: "0.2.6".into(),
             },
             VersionReq {
-                pob_ver: String::from("2.57.0"),
-                min_rpob_ver: String::from("0.2.6"),
+                pob_ver: "2.57.0".into(),
+                min_rpob_ver: "0.2.6".into(),
             },
             VersionReq {
-                pob_ver: String::from("2.58.1"),
-                min_rpob_ver: String::from("0.2.8"),
+                pob_ver: "2.58.1".into(),
+                min_rpob_ver: "0.2.8".into(),
             },
             VersionReq {
-                pob_ver: String::from("2.59.0"),
-                min_rpob_ver: String::from("0.2.9"),
+                pob_ver: "2.59.0".into(),
+                min_rpob_ver: "0.2.9".into(),
             },
             VersionReq {
-                pob_ver: String::from("2.59.1"),
-                min_rpob_ver: String::from("0.2.10"),
+                pob_ver: "2.59.1".into(),
+                min_rpob_ver: "0.2.10".into(),
             },
             VersionReq {
-                pob_ver: String::from("2.59.2"),
-                min_rpob_ver: String::from("0.2.10"),
+                pob_ver: "2.59.2".into(),
+                min_rpob_ver: "0.2.10".into(),
             },
         ];
         assert_eq!(highest_supported_pob_version(&compat_info, "0.0.2"), None);

--- a/src/installer/download.rs
+++ b/src/installer/download.rs
@@ -1,0 +1,275 @@
+use std::{
+    fmt,
+    fs::{self, File},
+    io::{self, Read, Write},
+    path::{Path, PathBuf},
+    thread,
+    time::{Duration, Instant},
+};
+
+use flate2::read::GzDecoder;
+use reqwest::blocking::{Client, Response};
+use tar::Archive;
+
+#[derive(Debug)]
+pub enum DownloadEvent {
+    Progress { downloaded: u64, total: Option<u64> },
+    Retrying { attempt: u32 },
+}
+
+/// Build a reqwest blocking client
+pub fn build_client() -> Result<Client, reqwest::Error> {
+    Client::builder().timeout(Duration::from_secs(60)).build()
+}
+
+// Rate-limit-aware GET.
+//
+// `raw.githubusercontent.com` doesn't seem to use `x-ratelimit-reset` and
+// `x-ratelimit-remaining` headers like the API so only the status code is checked.
+fn get_checked(client: &Client, url: &str) -> Result<Response, GithubError> {
+    let response = client.get(url).send()?;
+    let status = response.status();
+
+    if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        let retry_after_secs = response
+            .headers()
+            .get("retry-after")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(60);
+        return Err(GithubError::RateLimited {
+            retry_after_s: retry_after_secs,
+        });
+    }
+
+    if !status.is_success() {
+        return Err(GithubError::Http {
+            status: status.as_u16(),
+            url: url.to_string(),
+        });
+    }
+
+    Ok(response)
+}
+
+/// Wrapper to retry `f` up to `max_retries` times
+pub fn with_retry<T, F>(max_retries: u32, base_delay: Duration, mut f: F) -> Result<T, GithubError>
+where
+    F: FnMut(u32) -> Result<T, GithubError>,
+{
+    let mut attempt = 0;
+    loop {
+        match f(attempt) {
+            Err(GithubError::RateLimited {
+                retry_after_s: retry_after_secs,
+            }) if attempt < max_retries => {
+                log::warn!("Rate limited – sleeping {retry_after_secs}s (attempt {attempt})");
+                thread::sleep(Duration::from_secs(retry_after_secs));
+                attempt += 1;
+            }
+            Err(GithubError::Network(e)) if attempt < max_retries => {
+                let delay = base_delay * (attempt + 1);
+                log::warn!("Network error on attempt {attempt}: {e}. Retrying in {delay:?}");
+                thread::sleep(delay);
+                attempt += 1;
+            }
+            other => return other,
+        }
+    }
+}
+
+/// Download file contents from raw.githubusercontent.com into a `String`.
+pub fn fetch_file_contents(
+    client: &Client,
+    repo: &str,
+    file_name: &str,
+) -> Result<String, GithubError> {
+    let url = format!("https://raw.githubusercontent.com/{repo}/main/{file_name}");
+    let response = get_checked(client, &url)?;
+    Ok(response.text()?)
+}
+
+/// Download a file from raw.githubusercontent.com and write it to `dest_path`.
+pub fn download_file_to_disk<P: AsRef<Path>>(
+    client: &Client,
+    repo: &str,
+    file_name: &str,
+    dest_path: P,
+) -> Result<(), GithubError> {
+    let dest_path = dest_path.as_ref();
+
+    let url = format!("https://raw.githubusercontent.com/{repo}/main/{file_name}");
+    let mut response = get_checked(client, &url)?;
+
+    if let Some(parent) = dest_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut file = File::create(dest_path)?;
+    io::copy(&mut response, &mut file)?;
+    Ok(())
+}
+
+/// A rule describing how to map tarball entries to destination paths.
+///
+/// The root prefix is automatically striped and doesn't need to be specified.
+pub enum ExtractionRule {
+    /// Map a single file to an exact destination path.
+    File {
+        tarball_path: String,
+        dest_path: PathBuf,
+    },
+    /// Strip prefix from matching entries and place the remainder under `dest_dir`.
+    RewritePrefix { prefix: String, dest_dir: PathBuf },
+}
+
+/// Download a GitHub release tarball and extract entries to specified destinations.
+pub fn download_and_extract_tarball(
+    client: &Client,
+    repo_name: &str,
+    tag: &str,
+    rules: &[ExtractionRule],
+    max_retries: u32,
+    on_progress: &mut impl FnMut(DownloadEvent),
+) -> Result<(), GithubError> {
+    let url = format!("https://github.com/{repo_name}/archive/refs/tags/{tag}.tar.gz");
+
+    let tmp_path =
+        std::env::temp_dir().join(format!("gh-{}-{}.tar.gz", repo_name.replace('/', "-"), tag));
+
+    // Download to temp file
+    with_retry(max_retries, Duration::from_secs(5), |attempt| {
+        if attempt > 0 {
+            on_progress(DownloadEvent::Retrying { attempt });
+        }
+
+        let response = get_checked(client, &url)?;
+        let content_length = response.content_length();
+
+        let mut tmp_file = File::create(&tmp_path)?;
+        const CHUNK_SIZE: usize = 512 * 1024;
+        let mut chunk = vec![0u8; CHUNK_SIZE];
+        let mut downloaded: u64 = 0;
+        let mut body = response;
+
+        let mut last_progress = Instant::now();
+        const PROGRESS_INTERVAL: Duration = Duration::from_millis(50);
+
+        loop {
+            let n = body.read(&mut chunk)?;
+            if n == 0 {
+                break;
+            }
+            tmp_file.write_all(&chunk[..n])?;
+            downloaded += n as u64;
+
+            if last_progress.elapsed() >= PROGRESS_INTERVAL {
+                on_progress(DownloadEvent::Progress {
+                    downloaded,
+                    total: content_length,
+                });
+                last_progress = Instant::now();
+            }
+        }
+        on_progress(DownloadEvent::Progress {
+            downloaded,
+            total: content_length,
+        });
+
+        Ok(())
+    })?;
+
+    // Extract tarball to destination based on extract rules
+    let tmp_file = File::open(&tmp_path)?;
+    let gz = GzDecoder::new(io::BufReader::new(tmp_file));
+    let mut archive = Archive::new(gz);
+
+    let mut entries = archive.entries()?;
+
+    let root_prefix = {
+        let first = entries
+            .next()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::UnexpectedEof, "archive is empty"))??;
+        first.path()?.to_string_lossy().into_owned()
+    };
+
+    for entry_result in entries {
+        let mut entry = entry_result?;
+        let entry_path = entry.path()?.to_path_buf();
+        let entry_str = entry_path.to_string_lossy();
+
+        // Skip directory entries
+        if entry_str.ends_with('/') {
+            continue;
+        }
+
+        // Strip root prefix before matching against rules
+        let relative = match entry_str.strip_prefix(root_prefix.as_str()) {
+            Some(r) => r,
+            None => continue,
+        };
+
+        let dest: Option<PathBuf> = rules.iter().find_map(|rule| match rule {
+            ExtractionRule::File {
+                tarball_path,
+                dest_path,
+            } => (tarball_path == relative).then(|| dest_path.clone()),
+            ExtractionRule::RewritePrefix { prefix, dest_dir } => relative
+                .strip_prefix(prefix)
+                .map(|tail| dest_dir.join(tail)),
+        });
+
+        if let Some(dest_path) = dest {
+            if let Some(parent) = dest_path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            let mut dest_file = File::create(&dest_path)?;
+            io::copy(&mut entry, &mut dest_file)?;
+        }
+    }
+
+    fs::remove_file(&tmp_path)?;
+    Ok(())
+}
+
+#[derive(Debug)]
+pub enum GithubError {
+    Http { status: u16, url: String },
+    RateLimited { retry_after_s: u64 },
+    Network(reqwest::Error),
+    Io(io::Error),
+}
+
+impl fmt::Display for GithubError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Http { status, url } => write!(f, "HTTP error {status}: {url}"),
+            Self::RateLimited { retry_after_s } => {
+                write!(f, "Rate limited – retry after {retry_after_s}s")
+            }
+            Self::Network(e) => write!(f, "Network error: {e}"),
+            Self::Io(e) => write!(f, "I/O error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for GithubError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Network(e) => Some(e),
+            Self::Io(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<reqwest::Error> for GithubError {
+    fn from(e: reqwest::Error) -> Self {
+        Self::Network(e)
+    }
+}
+
+impl From<io::Error> for GithubError {
+    fn from(e: io::Error) -> Self {
+        Self::Io(e)
+    }
+}


### PR DESCRIPTION
Complete refactor of the installer:
- Uses reqwest instead of ureq which implements "Happy eyeballs" for better IPv4 + IPv6 dual stack handling. Solves https://github.com/meehl/rusty-path-of-building/issues/29
- Downloads tarball to temp file instead of streaming it directly to decoder. Not sure if this was the main cause but it seems to solve https://github.com/meehl/rusty-path-of-building/issues/36
- Lots of small adjustments and better documentation