### PR TITLE
Add GetVirtualScreenSize API function

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -15,8 +15,8 @@ use crate::{
         rendering::PoBString,
         search_handle::new_search_handle,
         window::{
-            get_dpi_scale_override, get_screen_scale, get_screen_size, set_dpi_scale_override,
-            set_foreground, set_window_title,
+            get_dpi_scale_override, get_screen_scale, get_screen_size, get_virtual_screen_size,
+            set_dpi_scale_override, set_foreground, set_window_title,
         },
     },
     lua::Context,
@@ -91,6 +91,10 @@ pub fn register_globals(lua: &Lua) -> LuaResult<()> {
 
     // window
     globals.set("GetScreenSize", lua.create_function(get_screen_size)?)?;
+    globals.set(
+        "GetVirtualScreenSize",
+        lua.create_function(get_virtual_screen_size)?,
+    )?;
     globals.set("GetScreenScale", lua.create_function(get_screen_scale)?)?;
     globals.set("SetWindowTitle", lua.create_function(set_window_title)?)?;
     globals.set("SetForeground", lua.create_function(set_foreground)?)?;

--- a/src/api/window.rs
+++ b/src/api/window.rs
@@ -16,6 +16,12 @@ pub fn get_screen_size(l: &Lua, _: ()) -> LuaResult<(u32, u32)> {
     Ok(size)
 }
 
+pub fn get_virtual_screen_size(l: &Lua, _: ()) -> LuaResult<(u32, u32)> {
+    let ctx = l.app_data_ref::<&'static Context>().unwrap();
+    let LogicalSize { width, height, .. } = ctx.window().logical_size();
+    Ok((width, height))
+}
+
 pub fn get_screen_scale(l: &Lua, _: ()) -> LuaResult<f32> {
     let ctx = l.app_data_ref::<&'static Context>().unwrap();
     let scale_factor = ctx.window().scale_factor();


### PR DESCRIPTION
Recent PoB2 scripts call `GetVirtualScreenSize()` during early startup (`Launch:DrawPopup`, e.g. when showing an update prompt or error popup), before the Lua fallback in `Modules/Common.lua` has been loaded. This crashed the runtime with:

```
runtime error: .../Launch.lua:397: attempt to call global 'GetVirtualScreenSize' (a nil value)
```

This adds `GetVirtualScreenSize` as a native API function returning the window size in logical (scale-independent) pixels — equivalent to the upstream fallback `GetScreenSize() / GetScreenScale()`, and to `GetScreenSize()` itself when not DPI-aware.

Tested with PoE2 on Linux/Wayland: the startup crash is gone and popups render at the correct size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)